### PR TITLE
chore: code connectファイルをpublishするworkflowを作成

### DIFF
--- a/.github/workflows/publish-figma-code-connect.yml
+++ b/.github/workflows/publish-figma-code-connect.yml
@@ -1,0 +1,18 @@
+name: Publish figma code connect
+on:
+  push:
+    branches: [main]
+    paths: ['**/*.figma.tsx']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.2.0'
+      - run: npm ci
+      - run: npm run figma:publish
+        env:
+          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}


### PR DESCRIPTION
## 📝 概要（What）


## 🎯 目的（Why）
- figma上にはレビューが通り、mainマージされたexampleが表示されるべき
- 毎回手動で実行が大変
そのためcoede connectファイルをpublishするワークフローを追加

## 🛠 変更内容（How）
.figma.tsxの差分かつmainマージされた時にpublishするワークフローを作成
